### PR TITLE
Add support for configuring timeouts in RubyBox::Session

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       nokogiri (= 1.5.10)
       rake
       rdoc
-    json (1.7.7)
+    json (1.8.6)
     jwt (0.1.5)
       multi_json (>= 1.0)
     multi_json (1.6.0)
@@ -67,3 +67,6 @@ DEPENDENCIES
   oauth2
   rspec
   webmock
+
+BUNDLED WITH
+   1.15.4

--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ p '@token.refresh_token' # token that can be exchanged for a new access_token on
 session = RubyBox::Session.new({
   client_id: 'your-client-id',
   client_secret: 'your-client-secret',
-  access_token: 'original-access-token' 
+  access_token: 'original-access-token'
 })
 
 # you need to persist this somehow. the refresh token will change every time you use it
@@ -58,6 +58,28 @@ session = RubyBox::Session.new({
 
 client = RubyBox::Client.new(session)
 ```
+
+Configuration
+=============
+
+The `RubyBox::Session` can take network timeout options, if desired:
+
+``` ruby
+session = RubyBox::Session.new({
+  client_id: 'your-client-id',
+  client_secret: 'your-client-secret',
+  access_token: 'access-token',
+  read_timeout: 60,
+  open_timeout: 30
+ })
+
+ ```
+
+ `read_timeout` and `open_timeout` are passed along to `Net::HTTP` if present. From the ruby documentations:
+
+ > read_timeout: Number of seconds to wait for one block to be read (via one read(2) call). Any number may be used, including Floats for fractional seconds.
+
+ > open_timeout: Number of seconds to wait for the connection to open. Any number may be used, including Floats for fractional seconds.
 
 Usage
 =====
@@ -172,7 +194,7 @@ p file.created_at
 
 ```ruby
 file = client.upload_file('./LICENSE.txt', '/license_folder') # lookups by id are more efficient
-file = client.upload_file_by_folder_id('./LICENSE.txt', @folder_id) 
+file = client.upload_file_by_folder_id('./LICENSE.txt', @folder_id)
 ```
 
 * Downloading a file.
@@ -334,7 +356,7 @@ Contributing to ruby-box
 ========================
 
 RubyBox does not yet support all of Box's API Version 2.0 functionality, be liberal with your contributions.
- 
+
 * Rename account.example to account.yml and fill in your Box credentials
 * Type bundle install
 * Type rake.. tests should pass

--- a/lib/ruby-box/session.rb
+++ b/lib/ruby-box/session.rb
@@ -12,9 +12,18 @@ module RubyBox
     def initialize(opts={}, backoff=0.1)
 
       @backoff = backoff # try not to excessively hammer API.
+      @read_timeout = opts[:read_timeout]
+      @open_timeout = opts[:open_timeout]
 
       if opts[:client_id]
-        @oauth2_client = OAuth2::Client.new(opts[:client_id], opts[:client_secret], OAUTH2_URLS.dup)
+        faraday_opts = {}
+        faraday_opts[:timeout] = @read_timeout if @read_timeout
+        faraday_opts[:open_timeout] = @open_timeout if @open_timeout
+
+        oauth2_opts = OAUTH2_URLS.dup.merge(connection_opts: { request: faraday_opts })
+        @oauth2_client = OAuth2::Client.new(opts[:client_id],
+                                            opts[:client_secret],
+                                            oauth2_opts)
         @access_token = OAuth2::AccessToken.new(@oauth2_client, opts[:access_token]) if opts[:access_token]
         @refresh_token = opts[:refresh_token]
         @as_user = opts[:as_user]
@@ -57,9 +66,10 @@ module RubyBox
     end
 
     def request(uri, request, raw=false, retries=0)
-
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
+      http.read_timeout = @read_timeout if @read_timeout
+      http.open_timeout = @open_timeout if @open_timeout
       #http.set_debug_output($stdout)
 
       if @access_token


### PR DESCRIPTION
The idea is to allow library users to configure network timeouts to suit their needs.

Copied from https://github.com/attachmentsme/ruby-box/pull/117